### PR TITLE
fix(install): manifest 补上共修 GitHub 两节课

### DIFF
--- a/install.md
+++ b/install.md
@@ -15,7 +15,7 @@
 1. **拿清单**：`curl -fsSL https://school.ha7ch.com/manifest.json`。`files` 每项有 `url`（相对 `https://school.ha7ch.com`）和 `dest`（相对 `<DIR>`）。
 2. **逐个下载**：先 `mkdir -p` 每个 dest 的父目录，再 `curl -fsSL https://school.ha7ch.com/<url> -o <DIR>/<dest>`。
    - ⚠️ 关键：`school.md` 的 dest 是 `SKILL.md`（入口必须叫 SKILL.md）。
-3. **校验**：`<DIR>/SKILL.md` 存在，且 `references/` 下有 12 个 `.md`。
+3. **校验**：`<DIR>/SKILL.md` 存在，且 `references/` 下有 15 个 `.md`（以 manifest 的 `files` 数为准）。
 
 ## 第三步 · 开课
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "ha7ch-school",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "base": "https://school.ha7ch.com",
   "files": [
     {
@@ -46,6 +46,14 @@
     {
       "url": "references/lessons/fde/04-four-cities-report.md",
       "dest": "references/lessons/fde/04-four-cities-report.md"
+    },
+    {
+      "url": "references/lessons/shared/github-concepts.md",
+      "dest": "references/lessons/shared/github-concepts.md"
+    },
+    {
+      "url": "references/lessons/shared/github-lab-first-pr.md",
+      "dest": "references/lessons/shared/github-lab-first-pr.md"
     },
     {
       "url": "references/pedagogy.md",


### PR DESCRIPTION
PR #1 的共修课漏了更新 `manifest.json`——走 install.md 安装路径的学生会缺 `references/lessons/shared/` 两个文件（免安装托管模式不受影响）。本 PR 补上清单并把 install.md 的校验数从过期的 12 修正为 15。

🤖 Generated with [Claude Code](https://claude.com/claude-code)