### PR TITLE
feat(cli): @ha7ch/school npx 一键安装器

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,17 @@
 
 ## 安装
 
-把这个仓库放到你的 Claude Code 个人 skill 目录：
+最快是一条 npx：
 
 ```bash
-git clone <this-repo> ~/.claude/skills/ha7ch-school
-# 或把仓库内容复制到 ~/.claude/skills/ha7ch-school/
+npx @ha7ch/school            # 自动探测装到 ~/.claude/skills/ha7ch-school
+npx @ha7ch/school --codex    # Codex 用户装到 ~/.codex/skills/
+npx @ha7ch/school --force    # 更新到最新（学习进度在 ~/.ha7ch-school/，不受影响）
 ```
 
-然后在 Claude Code 里 `/ha7ch-school`（或对它说"带我学 AI Native / 想学 FDE / ha7ch school"）即可入学。
+其它方式：把「读 https://school.ha7ch.com/install.md ，帮我把 HA7CH School 装上」贴给你的 agent；免安装则贴「读 https://school.ha7ch.com/school.md ，带我上课」；开发者也可以直接 `git clone https://github.com/HA7CH/ha7ch-school ~/.claude/skills/ha7ch-school`。
+
+装好后在 Claude Code 里 `/ha7ch-school`（或对它说"带我学 AI Native / 想学 FDE / ha7ch school"）即可入学。
 
 **配套 skill（实验课会用到，按需装）**：`cv-pro`、`fde-pro`（都在小红书 SkillHub 可装）。没装也能上，导师会把实操降级成带你走一遍。
 

--- a/cli/.gitignore
+++ b/cli/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+skill

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,19 @@
+# @ha7ch/school
+
+一条命令把 [HA7CH AI Native School](https://school.ha7ch.com) 装进你的 Claude Code / Codex skill 目录。
+
+```bash
+npx @ha7ch/school
+```
+
+默认自动探测装到 `~/.claude/skills/ha7ch-school`（有 `~/.codex` 没有 `~/.claude` 时装到 Codex 目录）。也可以自己指定：
+
+```bash
+npx @ha7ch/school --codex          # 强制装到 ~/.codex/skills/ha7ch-school
+npx @ha7ch/school --dir <path>     # 装到自定义目录
+npx @ha7ch/school --force          # 已装过时覆盖成最新内容（学习进度在 ~/.ha7ch-school/，不受影响）
+```
+
+装完新开一个会话，说「带我学 AI Native」「想学 FDE」，或者在 Claude Code 里 `/ha7ch-school`，即可入学。
+
+课程讲什么、锚定了哪些真实素材，见仓库根目录 [README.md](https://github.com/HA7CH/ha7ch-school#readme)。

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,573 @@
+{
+  "name": "@ha7ch/school",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@ha7ch/school",
+      "version": "1.1.0",
+      "license": "MIT",
+      "bin": {
+        "ha7ch-school": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^20",
+        "tsx": "^4",
+        "typescript": "^5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/tsx": {
+      "version": "4.23.1",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.1.tgz",
+      "integrity": "sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "@ha7ch/school",
+  "version": "1.1.0",
+  "description": "把 HA7CH AI Native School（AI Native / FDE 两门课 + 共修 GitHub 节点）一条命令装进 Claude Code / Codex 的 skill 目录",
+  "homepage": "https://school.ha7ch.com",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/HA7CH/ha7ch-school.git"
+  },
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "ha7ch-school": "dist/index.js"
+  },
+  "files": [
+    "dist",
+    "skill"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
+  },
+  "scripts": {
+    "prepare-skill": "node scripts/prepare-skill.mjs",
+    "prebuild": "npm run prepare-skill",
+    "build": "tsc",
+    "dev": "npm run prepare-skill && tsx src/index.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "@types/node": "^20",
+    "typescript": "^5",
+    "tsx": "^4"
+  },
+  "engines": {
+    "node": ">=18"
+  }
+}

--- a/cli/scripts/prepare-skill.mjs
+++ b/cli/scripts/prepare-skill.mjs
@@ -1,0 +1,30 @@
+// Copies the repo's skill content (SKILL.md + references/) into cli/skill/
+// so it ships inside the published npm package. Runs before every build.
+// references/harvest/ 是采集工作区，不属于课程内容，不打进包。
+import { cpSync, rmSync, existsSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(here, "..", "..");
+const cliRoot = join(here, "..");
+const dest = join(cliRoot, "skill");
+
+const skillMdSrc = join(repoRoot, "SKILL.md");
+const referencesSrc = join(repoRoot, "references");
+const harvestDir = join(referencesSrc, "harvest");
+
+if (!existsSync(skillMdSrc) || !existsSync(referencesSrc)) {
+  console.error(`prepare-skill: expected ${skillMdSrc} and ${referencesSrc} to exist — run this from the ha7ch-school repo.`);
+  process.exit(1);
+}
+
+rmSync(dest, { recursive: true, force: true });
+mkdirSync(dest, { recursive: true });
+cpSync(skillMdSrc, join(dest, "SKILL.md"));
+cpSync(referencesSrc, join(dest, "references"), {
+  recursive: true,
+  filter: (src) => !src.startsWith(harvestDir),
+});
+
+console.log(`prepare-skill: bundled skill content into ${dest}`);

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+import { existsSync, mkdirSync, cpSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pkg = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as { version: string };
+
+const HELP = `
+ha7ch-school — install the HA7CH AI Native School skill
+https://school.ha7ch.com
+
+USAGE
+  npx @ha7ch/school [options]
+
+OPTIONS
+  --dir <path>     Install to a custom directory (default: auto-detect)
+  --codex          Install into ~/.codex/skills/ha7ch-school instead of Claude Code
+  --force          Overwrite an existing install with the latest content
+  -h, --help       Show this help
+  -v, --version    Show version
+
+WHAT THIS DOES
+  Copies the ha7ch-school skill (SKILL.md + references/) into your
+  agent's local skills directory. Everything needed ships inside this
+  package — no account, no extra network calls at install time.
+
+AFTER INSTALL
+  Start a new session in your agent, then say 「带我学 AI Native」/「想学 FDE」
+  or run /ha7ch-school (Claude Code) to enroll.
+`;
+
+type Args = {
+  dir?: string;
+  codex: boolean;
+  force: boolean;
+  help: boolean;
+  version: boolean;
+};
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = { codex: false, force: false, help: false, version: false };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--dir") args.dir = argv[++i];
+    else if (a === "--codex") args.codex = true;
+    else if (a === "--force") args.force = true;
+    else if (a === "-h" || a === "--help") args.help = true;
+    else if (a === "-v" || a === "--version") args.version = true;
+  }
+  return args;
+}
+
+function resolveTargetDir(args: Args): string {
+  if (args.dir) return args.dir;
+  const home = homedir();
+  if (args.codex) return join(home, ".codex", "skills", "ha7ch-school");
+  if (existsSync(join(home, ".claude"))) return join(home, ".claude", "skills", "ha7ch-school");
+  if (existsSync(join(home, ".codex"))) return join(home, ".codex", "skills", "ha7ch-school");
+  return join(home, ".claude", "skills", "ha7ch-school");
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    console.log(HELP);
+    return;
+  }
+  if (args.version) {
+    console.log(pkg.version);
+    return;
+  }
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  const skillSrc = join(here, "..", "skill");
+  if (!existsSync(skillSrc)) {
+    console.error(
+      "Bundled skill content not found — this package build is broken. Please report at https://github.com/HA7CH/ha7ch-school/issues",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const target = resolveTargetDir(args);
+
+  if (existsSync(target) && !args.force) {
+    console.log(`⚠️  ${target} already exists.`);
+    console.log(
+      "   Re-run with --force to overwrite it with the latest content (your learning progress lives separately in ~/.ha7ch-school/ and is never touched).",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  mkdirSync(target, { recursive: true });
+  cpSync(skillSrc, target, { recursive: true });
+
+  console.log(`✅ Installed HA7CH AI Native School (v${pkg.version}) to:`);
+  console.log(`   ${target}`);
+  console.log("");
+  console.log("Start a new session in your agent, then say 「带我学 AI Native」/「想学 FDE」");
+  console.log("or run /ha7ch-school (Claude Code) to enroll.");
+}
+
+main();

--- a/cli/tsconfig.json
+++ b/cli/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"]
+}

--- a/index.html
+++ b/index.html
@@ -95,6 +95,10 @@
     <div class="ol-tag alt">免安装 · 随时试</div>
     <code class="ol-code">读 https://school.ha7ch.com/school.md ，带我上课</code>
   </div>
+  <div class="oneliner">
+    <div class="ol-tag alt">会用终端 · npx 直装</div>
+    <code class="ol-code">npx @ha7ch/school</code>
+  </div>
   <p class="note">课程内容托管在本站、永远最新；一句话让你的 agent 自己把学校接上。学习进度存在你自己机器上。</p>
 
   <div class="links">

--- a/install.md
+++ b/install.md
@@ -2,6 +2,16 @@
 
 > 本页是给**正在运行的 AI agent**（Claude Code / Codex / 其它）读的安装说明。用户已让你安装 HA7CH School。请照下面把它装成本地 skill，再开始上课。别把本页当课程内容念给用户。
 
+## 第 0 步 · 最快路径：npx 一条命令（环境里有 node 就用这条）
+
+```bash
+npx -y @ha7ch/school@latest            # 自动探测装到 ~/.claude/skills/ha7ch-school
+npx -y @ha7ch/school@latest --codex    # 你是 Codex 就加 --codex
+npx -y @ha7ch/school@latest --force    # 已装过、想更新到最新
+```
+
+成功（打印 ✅ Installed）就直接跳到「第三步 · 开课」。没有 node / npx 跑不了，再走下面第一、二步手动下载。
+
 ## 第一步 · 确定装到哪个目录（按你是哪个 agent，你自己知道）
 
 - **Claude Code** → `~/.claude/skills/ha7ch-school/`


### PR DESCRIPTION
补上 school 的 npx 安装方式，镜像 `@ha7ch/stanford-pro` 的成熟模式：

```bash
npx @ha7ch/school            # 自动探测装到 ~/.claude/skills/ha7ch-school
npx @ha7ch/school --codex    # 装到 ~/.codex/skills/
npx @ha7ch/school --force    # 更新（进度在 ~/.ha7ch-school/ 不受影响）
```

- 内容在 publish 时打进包本体（SKILL.md + references/，排除 harvest 工作区）——装机零网络请求、零账号
- `install.md` 加「第 0 步 · npx 最快路径」（agent 有 node 直接跑，没有再走 manifest 手动下载）；`index.html`/`README` 同步宣传
- 本地实测：装出 16 个 md（含共修 GitHub 两节）、二次运行守卫、harvest 排除，全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)