### PR TITLE
修复 CI：安全处理落后于主干的校友墙 PR

### DIFF
--- a/.github/scripts/wall-pr-bot.mjs
+++ b/.github/scripts/wall-pr-bot.mjs
@@ -189,15 +189,13 @@ async function main() {
     return;
   }
 
-  const [files, base, head] = await Promise.all([
+  const [files, head] = await Promise.all([
     getPullFiles(),
-    getFile(repository, "WALL.md", pr.base.sha),
     getFile(pr.head.repo.full_name, "WALL.md", pr.head.sha),
   ]);
   const policy = validateWallChange({
     pr,
     files,
-    baseContent: base.content,
     headContent: head.content,
   });
 

--- a/.github/scripts/wall-pr-policy.mjs
+++ b/.github/scripts/wall-pr-policy.mjs
@@ -32,8 +32,9 @@ export function appendEntry(content, line) {
   return { content: `${content}${line}\n`, added: true };
 }
 
-export function validateWallChange({ pr, files, baseContent, headContent }) {
+export function validateWallChange({ pr, files, headContent }) {
   const errors = [];
+  const wallFile = Array.isArray(files) && files.length === 1 ? files[0] : null;
 
   if (!pr || pr.state !== "open") errors.push("PR 不是 open 状态");
   if (pr?.draft) errors.push("Draft PR 不自动处理");
@@ -42,7 +43,7 @@ export function validateWallChange({ pr, files, baseContent, headContent }) {
   if (!Array.isArray(files) || files.length !== 1) {
     errors.push("必须且只能修改一个文件");
   } else {
-    const [file] = files;
+    const file = wallFile;
     if (file.filename !== WALL_PATH) errors.push(`只能修改 ${WALL_PATH}`);
     if (file.status !== "modified") errors.push(`${WALL_PATH} 必须是追加修改`);
     if (file.additions !== 1 || file.deletions !== 0 || file.changes !== 1) {
@@ -50,25 +51,31 @@ export function validateWallChange({ pr, files, baseContent, headContent }) {
     }
   }
 
-  if (typeof baseContent !== "string" || typeof headContent !== "string") {
-    errors.push("无法读取 PR 两端的 WALL.md");
+  if (typeof headContent !== "string") {
+    errors.push("无法读取 PR 提交版本的 WALL.md");
+    return { ok: false, errors };
+  }
+  if (!headContent.endsWith("\n")) {
+    errors.push("PR 提交版本的 WALL.md 末尾缺少换行");
     return { ok: false, errors };
   }
 
-  if (!baseContent.endsWith("\n")) errors.push("基线 WALL.md 末尾缺少换行");
-  if (!headContent.startsWith(baseContent)) {
-    errors.push("PR 改写了 WALL.md 的既有内容，不是纯末尾追加");
+  const patchAddedLines = String(wallFile?.patch || "")
+    .split("\n")
+    .filter((line) => line.startsWith("+") && !line.startsWith("+++"))
+    .map((line) => line.slice(1));
+  if (patchAddedLines.length !== 1) {
+    errors.push("GitHub patch 必须能确认恰好新增一行");
     return { ok: false, errors };
   }
 
-  const suffix = headContent.slice(baseContent.length);
-  const suffixLines = suffix.split("\n");
-  if (suffixLines.length !== 2 || suffixLines[1] !== "" || !suffixLines[0]) {
-    errors.push("必须在 WALL.md 末尾恰好追加一行，并保留文件末尾换行");
-    return { ok: false, errors };
+  const headLines = headContent.slice(0, -1).split("\n");
+  const line = headLines.at(-1);
+  if (!line || patchAddedLines[0] !== line) {
+    errors.push("新增行必须位于 PR 提交版本的 WALL.md 文件末尾");
+    return { ok: false, errors, line: patchAddedLines[0] };
   }
 
-  const line = suffixLines[0];
   const match = line.match(
     /^- (\d{4}-\d{2}-\d{2}) · @([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?) · (\S.*)$/,
   );

--- a/.github/scripts/wall-pr-policy.test.mjs
+++ b/.github/scripts/wall-pr-policy.test.mjs
@@ -22,6 +22,7 @@ const files = [
     additions: 1,
     deletions: 0,
     changes: 1,
+    patch: `@@ -3,1 +3,2 @@\n - 2026-08-01 · @HA7CH · 开墙\n+${validLine}`,
   },
 ];
 
@@ -29,7 +30,6 @@ test("accepts one authored line appended to WALL.md", () => {
   const result = validateWallChange({
     pr,
     files,
-    baseContent,
     headContent: `${baseContent}${validLine}\n`,
   });
   assert.equal(result.ok, true);
@@ -40,7 +40,6 @@ test("rejects changes outside WALL.md", () => {
   const result = validateWallChange({
     pr,
     files: [{ ...files[0], filename: "README.md" }],
-    baseContent,
     headContent: `${baseContent}${validLine}\n`,
   });
   assert.equal(result.ok, false);
@@ -51,7 +50,6 @@ test("rejects edits mixed with the appended line", () => {
   const result = validateWallChange({
     pr,
     files: [{ ...files[0], deletions: 1, changes: 2 }],
-    baseContent,
     headContent: `${baseContent}${validLine}\n`,
   });
   assert.equal(result.ok, false);
@@ -62,12 +60,30 @@ test("rejects a wall handle that differs from the PR author", () => {
   const otherLine = "- 2026-08-25 · @someone-else · 代别人上墙";
   const result = validateWallChange({
     pr,
-    files,
-    baseContent,
+    files: [{ ...files[0], patch: `@@ -3,1 +3,2 @@\n+${otherLine}` }],
     headContent: `${baseContent}${otherLine}\n`,
   });
   assert.equal(result.ok, false);
   assert.match(result.errors.join(" "), /必须与 PR 作者/);
+});
+
+test("accepts a stale branch when its patch is one valid EOF append", () => {
+  const result = validateWallChange({
+    pr,
+    files,
+    headContent: `${baseContent}${validLine}\n`,
+  });
+  assert.equal(result.ok, true);
+});
+
+test("rejects one added line when it was inserted before the file end", () => {
+  const result = validateWallChange({
+    pr,
+    files,
+    headContent: `# Wall\n\n${validLine}\n- 2026-08-01 · @HA7CH · 开墙\n`,
+  });
+  assert.equal(result.ok, false);
+  assert.match(result.errors.join(" "), /文件末尾/);
 });
 
 test("extracts and deduplicates explicit closing references", () => {


### PR DESCRIPTION
首轮用 #59 做真实 `pull_request_target` 验证时，工作流安全失败：GitHub 在 PR reopened 后会把 `base.sha` 更新为最新主干，使合法旧分支不再以当前 base 内容为前缀。

本修复改用两份独立证据：

1. GitHub PR patch 必须显示整个 PR 只新增一行、无删除；
2. 这唯一新增行必须也是 PR head 版本 `WALL.md` 的最后一行。

因此可以接受合法旧分支并进入冲突汇总，同时继续拒绝中间插入、改写旧行、夹带文件和代别人上墙。

验证：`node --test .github/scripts/wall-pr-policy.test.mjs` 10/10，包含 stale branch 接受和非 EOF 插入拒绝。